### PR TITLE
PROTO-1319: get functioning discovery node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,5 @@ WORKDIR /root/audius-docker-compose
 RUN echo "NETWORK='$NETWORK'" > ./creator-node/.env
 RUN echo "NETWORK='$NETWORK'" > ./discovery-provider/.env
 
-# docker volumes will initially create these as dirs if they don't exist
-# create them here since this is a new audius-docker-compose clone
-RUN touch discovery-provider/chain/spec.json
-RUN touch discovery-provider/chain/static-nodes.json
-
 RUN python3 -m pip install -r requirements.txt
 RUN ln -sf $PWD/audius-cli /usr/local/bin/audius-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,10 @@ WORKDIR /root/audius-docker-compose
 RUN echo "NETWORK='$NETWORK'" > ./creator-node/.env
 RUN echo "NETWORK='$NETWORK'" > ./discovery-provider/.env
 
+# docker volumes will initially create these as dirs if they don't exist
+# create them here since this is a new audius-docker-compose clone
+RUN touch discovery-provider/chain/spec.json
+RUN touch discovery-provider/chain/static-nodes.json
+
 RUN python3 -m pip install -r requirements.txt
 RUN ln -sf $PWD/audius-cli /usr/local/bin/audius-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM docker:dind
 ARG NETWORK=prod
 ARG BRANCH=main
 
-RUN apk add bash git
+RUN apk add bash git curl libc-dev gcc python3 py3-pip python3-dev linux-headers
 
 VOLUME /var/k8s/creator-node-db
 VOLUME /var/k8s/mediorum
@@ -16,3 +16,6 @@ RUN git clone --single-branch --branch "$BRANCH" https://github.com/AudiusProjec
 WORKDIR /root/audius-docker-compose
 RUN echo "NETWORK='$NETWORK'" > ./creator-node/.env
 RUN echo "NETWORK='$NETWORK'" > ./discovery-provider/.env
+
+RUN python3 -m pip install -r requirements.txt
+RUN ln -sf $PWD/audius-cli /usr/local/bin/audius-cli

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ audius: main.go
 
 build-docker:
 	@echo "Building Docker image..."
-	docker buildx build --load --build-arg NETWORK=stage -t audius/dot-slash:dev .
+	docker buildx build --load --build-arg NETWORK=stage --build-arg BRANCH=as/dot-slash-audius -t audius/dot-slash:dev .
 
 push-docker:
 	@echo "Pushing Docker image..."

--- a/audius.conf
+++ b/audius.conf
@@ -1,10 +1,6 @@
-# creator-node
-creatorNodeEndpoint=
-delegateOwnerWallet=
-delegatePrivateKey=
-spOwnerWallet=
-
 # discovery-provider
 audius_discprov_url=
 audius_delegate_owner_wallet=
 audius_delegate_private_key=
+audius_auto_upgrade_enabled='false'
+AUDIUS_DOCKER_COMPOSE_GIT_SHA='a5131497136a225f7f85c28d1e2e01712080baf7'

--- a/main.go
+++ b/main.go
@@ -140,11 +140,9 @@ func runUp(nodeType string) {
 
 	audiusCli("set-network", "stage")
 
-	runCommand("/bin/sh", "-c", `docker exec discovery-provider sh -c "[ -d "/discovery-provider/chain/spec.json" ] && rm -r "/discovery-provider/chain/spec.json""`)
-	runCommand("/bin/sh", "-c", `docker exec discovery-provider sh -c "[ -d "/discovery-provider/chain/static-nodes.json" ] && rm -r "/discovery-provider/chain/static-nodes.json""`)
-
-	audiusCli(launchCmd...)
+	// this will create the right files first
 	audiusCli("launch-chain")
+	audiusCli(launchCmd...)
 }
 
 func runDown() {

--- a/main.go
+++ b/main.go
@@ -133,15 +133,13 @@ func runUp(nodeType string) {
 		exitWithError("Error executing command:", err)
 	}
 
+	audiusCli("set-network", "stage")
+	audiusCli("launch-chain")
+
 	launchCmd := []string{"launch", "discovery-provider", "-y"}
 	if seed {
 		launchCmd = append(launchCmd, "--seed")
 	}
-
-	audiusCli("set-network", "stage")
-
-	// this will create the right files first
-	audiusCli("launch-chain")
 	audiusCli(launchCmd...)
 }
 

--- a/main.go
+++ b/main.go
@@ -133,13 +133,16 @@ func runUp(nodeType string) {
 		exitWithError("Error executing command:", err)
 	}
 
-	audiusCli("set-network", "stage")
+	launchCmd := []string{"launch", "discovery-provider", "-y"}
 	if seed {
-		audiusCli("launch", "discovery-provider", "-y", "--seed")
-	} else {
-		audiusCli("launch", "discovery-provider", "-y")
+		launchCmd = append(launchCmd, "--seed")
 	}
-	audiusCli("launch-chain")
+
+	audiusCli("set-network", "stage")
+
+	// run these concurrently
+	go audiusCli(launchCmd...)
+	go audiusCli("launch-chain")
 }
 
 func runDown() {

--- a/main.go
+++ b/main.go
@@ -140,6 +140,9 @@ func runUp(nodeType string) {
 
 	audiusCli("set-network", "stage")
 
+	runCommand("/bin/sh", "-c", `docker exec discovery-provider sh -c "[ -d "/discovery-provider/chain/spec.json" ] && rm -r "/discovery-provider/chain/spec.json""`)
+	runCommand("/bin/sh", "-c", `docker exec discovery-provider sh -c "[ -d "/discovery-provider/chain/static-nodes.json" ] && rm -r "/discovery-provider/chain/static-nodes.json""`)
+
 	audiusCli(launchCmd...)
 	audiusCli("launch-chain")
 }

--- a/main.go
+++ b/main.go
@@ -140,9 +140,8 @@ func runUp(nodeType string) {
 
 	audiusCli("set-network", "stage")
 
-	// run these concurrently
-	go audiusCli(launchCmd...)
-	go audiusCli("launch-chain")
+	audiusCli(launchCmd...)
+	audiusCli("launch-chain")
 }
 
 func runDown() {


### PR DESCRIPTION
Have to finish testing on `alec-sandbox`:
- installs `audius-cli` right onto the box making it available to the go binary, we can piecemeal replace different pieces of this as we go
- after audius-cli is removed entirely we can get rid of all the python/gcc deps introduced here
- stands up discovery node via audius-cli within dind, this is the quickest way to get the chain operating correctly
- adds seeding capability to the discovery node as well
Blocked on this:
- https://github.com/AudiusProject/audius-docker-compose/pull/387
