### PR TITLE
Add audius-cli to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM docker:dind
 ARG NETWORK=prod
 ARG BRANCH=main
 
-RUN apk add bash git
+RUN apk add bash git curl libc-dev gcc python3 py3-pip python3-dev linux-headers
 
 VOLUME /var/k8s/creator-node-db
 VOLUME /var/k8s/mediorum
@@ -16,3 +16,6 @@ RUN git clone --single-branch --branch "$BRANCH" https://github.com/AudiusProjec
 WORKDIR /root/audius-docker-compose
 RUN echo "NETWORK='$NETWORK'" > ./creator-node/.env
 RUN echo "NETWORK='$NETWORK'" > ./discovery-provider/.env
+
+RUN python3 -m pip install -r requirements.txt
+RUN ln -sf $PWD/audius-cli /usr/local/bin/audius-cli

--- a/main.go
+++ b/main.go
@@ -27,8 +27,8 @@ func main() {
 	flag.BoolVar(&localImage, "local", false, "when specified, will use docker image from local repository")
 	flag.IntVar(&port, "port", 80, "specify a custom http port")
 	flag.IntVar(&tlsPort, "tls", 443, "specify a custom https port")
-	
-	if ! regexp.MustCompile(`^[a-zA-Z0-9_\-]+$`).MatchString(imageTag) {
+
+	if !regexp.MustCompile(`^[a-zA-Z0-9_\-]+$`).MatchString(imageTag) {
 		exitWithError("Invalid image tag:", imageTag)
 	}
 	cmdName := "up"
@@ -90,7 +90,7 @@ func runUp(nodeType string) {
 	ensureDirectory("/tmp/dind")
 
 	if !localImage {
-		if err := runCommand("docker", "pull", "audius/dot-slash:" + imageTag); err != nil {
+		if err := runCommand("docker", "pull", "audius/dot-slash:"+imageTag); err != nil {
 			exitWithError("Error pulling image:", err)
 		}
 	}
@@ -134,6 +134,15 @@ func ensureDirectory(path string) {
 		if err := os.MkdirAll(path, 0755); err != nil {
 			exitWithError("Failed to create directory:", err)
 		}
+	}
+}
+
+func audiusCli(args ...string) {
+	audCli := []string{"exec", "discovery-provider", "audius-cli"}
+	cmds := append(audCli, args...)
+	err := runCommand("docker", cmds...)
+	if err != nil {
+		exitWithError("Error with audius-cli:", err)
 	}
 }
 


### PR DESCRIPTION
Installs some deps as well as audius-cli into the docker container for easy adoption of those who need it. I think we can phase out what audius-cli does with the script in pieces.