### PR TITLE
PROTO-1334: functioning identity

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,6 +143,7 @@ func runUp() {
 		}
 		audiusCli(launchCmd...)
 	case "identity-service":
+		audiusCli("launch", "identity-service", "-y")
 	default:
 		exitWithError(fmt.Sprintf("provided node type is not supported: %s", nodeType))
 	}


### PR DESCRIPTION
PR number four:
Still a draft as this seems to stand up a discovery node despite the logic being fine. 

Notes:
- identity has a RDS database so won't fully know that until testing on stage or using the same stage config